### PR TITLE
Suporte a criação de constantes e variáveis dentro de string

### DIFF
--- a/src/Lang/pt_BR/app.yml
+++ b/src/Lang/pt_BR/app.yml
@@ -4,6 +4,7 @@ code:
     echo-scalar: Imprime na tela :value
     assign: A variável :var recebe o valor :value
     assign-op: A variável :var recebe :value
+    const: A constante :const recebe o valor :value
     array: o conjunto de valores :value
     binary-op: o valor :value resultante da operação :expr
     binary-op-var: o valor :value resultante da operação :expr onde :where

--- a/src/Node/Scalar/Encapsed.php
+++ b/src/Node/Scalar/Encapsed.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpTestBed\Node\Scalar;
+
+use PhpTestBed\I18n;
+use PhpTestBed\Stylizer;
+
+class Encapsed extends \PhpTestBed\ResolverAbstract
+{
+
+    private $result = '';
+    private $expr = '';
+    private $usedVars = array();
+
+    public function __construct(\PhpParser\Node\Scalar\Encapsed $node)
+    {
+        parent::__construct($node);
+    }
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    public function getExpr()
+    {
+        return Stylizer::value($this->expr);
+    }
+
+    public function getUsedVars()
+    {
+        return $this->usedVars;
+    }
+
+    protected function resolve()
+    {
+        foreach ($this->node->parts as $expr) {
+            switch (get_class($expr)) {
+                case \PhpParser\Node\Scalar\EncapsedStringPart::class:
+                    $this->result .= $expr->value;
+                    $this->expr .= $expr->value;
+                    break;
+                case \PhpParser\Node\Expr\Variable::class:
+                    $value = \PhpTestBed\Repository::getInstance()->get($expr->name);
+                    $this->result .= $value;
+                    $this->expr .= Stylizer::variable("\${$expr->name}");
+                    $this->usedVars[$expr->name] = $value;
+                    break;
+            }
+        }
+    }
+
+}

--- a/src/Node/Stmt/Const_.php
+++ b/src/Node/Stmt/Const_.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpTestBed\Node\Stmt;
+
+use PhpTestBed\I18n;
+use PhpTestBed\Stylizer;
+
+class Const_ extends \PhpTestBed\ResolverAbstract
+{
+
+    public function __construct(\PhpParser\Node\Stmt\Const_ $node)
+    {
+        parent::__construct($node);
+    }
+
+    protected function resolve()
+    {
+        foreach ($this->node->consts as $expr) {
+            if ($expr->value instanceof \PhpParser\Node\Scalar) {
+                $mVar = [
+                    'const' => Stylizer::variable($expr->name),
+                    'value' => Stylizer::value($expr->value->value)
+                ];
+                $this->printMessage(I18n::getInstance()->get('code.const', $mVar));
+                \PhpTestBed\Repository::getInstance()->setConst($expr->name, $expr->value->value);
+            }
+        }
+    }
+
+}

--- a/src/Node/Stmt/Echo_.php
+++ b/src/Node/Stmt/Echo_.php
@@ -16,8 +16,19 @@ class Echo_ extends \PhpTestBed\ResolverAbstract
     protected function resolve()
     {
         foreach ($this->node->exprs as $expr) {
-            if ($expr instanceof \PhpParser\Node\Scalar) {
-                $mVar = [ 
+            if ($expr instanceof \PhpParser\Node\Scalar\Encapsed) {
+                $enc = new \PhpTestBed\Node\Scalar\Encapsed($expr);
+                $eVar = [
+                    'value' => Stylizer::value($enc->getResult()),
+                    'expr' => Stylizer::expression($enc->getExpr()),
+                    'where' => \PhpTestBed\Repository::showUsed([], $enc->getUsedVars())
+                ];
+                $mVar = [
+                    'value' => I18n::getInstance()->get('code.binary-op-var', $eVar)
+                ];
+                $this->printMessage(I18n::getInstance()->get('code.echo-scalar', $mVar));
+            } elseif ($expr instanceof \PhpParser\Node\Scalar) {
+                $mVar = [
                     'value' => Stylizer::value($expr->value)
                 ];
                 $this->printMessage(I18n::getInstance()->get('code.echo-scalar', $mVar));

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -2,30 +2,66 @@
 
 namespace PhpTestBed;
 
+use PhpTestBed\Stylizer;
+
 class Repository
 {
 
     use \FlorianWolters\Component\Util\Singleton\SingletonTrait;
 
-    private $repository = array();
+    private $variables = array();
+    private $constants = array();
 
     public function get($key)
     {
-        if (!array_key_exists($key, $this->repository)) {
-            //trigger_error("Key for \$$key does not exists at variable repository.", E_USER_NOTICE);
+        if (!array_key_exists($key, $this->variables)) {
             return null;
         }
-        return $this->repository[$key];
+        return $this->variables[$key];
     }
 
     public function set($key, $value)
     {
-        $this->repository[$key] = $value;
+        $this->variables[$key] = $value;
     }
 
-    public function getRepository()
+    public function getVariables()
     {
-        return $this->repository;
+        return $this->variables;
+    }
+
+    public function getConst($key)
+    {
+        if (!array_key_exists($key, $this->constants)) {
+            return null;
+        }
+        return $this->constants[$key];
+    }
+
+    public function setConst($key, $value)
+    {
+        $this->constants[$key] = $value;
+    }
+
+    public static function showUsed(array $consts, array $vars)
+    {
+        $used = '';
+        foreach ($consts as $const => $value) {
+            $used .= sprintf('%s %s %s, '
+                    , Stylizer::variable($const)
+                    , Stylizer::operation('=')
+                    , Stylizer::type($value));
+        }
+        foreach ($vars as $var => $value) {
+            $used .= sprintf('%s %s %s, '
+                    , Stylizer::variable("$$var")
+                    , Stylizer::operation('=')
+                    , Stylizer::type($value));
+        }
+        if (!empty($used)) {
+            $used = substr($used, 0, -2);
+        }
+        return $used;
     }
 
 }

--- a/src/ScriptCrawler.php
+++ b/src/ScriptCrawler.php
@@ -46,7 +46,7 @@ class ScriptCrawler
         $this->printMessage(I18n::getInstance()->get('messages.start'));
         $this->crawl($this->nodes);
         $this->printMessage(I18n::getInstance()->get('messages.end'));
-        var_dump(Repository::getInstance()->getRepository());
+        var_dump(Repository::getInstance()->getVariables());
         var_dump($this->nodes);
         if ($this->returnMessages) {
             return $this->messages;

--- a/test.php
+++ b/test.php
@@ -1,7 +1,14 @@
 <?php
 
+const FILE = 'test', TYPE = 'php';
+
 $a = 10;
+
+echo "Ola $a Jow " . FILE . TYPE;
+
 $d = $a << 2;
+
+echo "Teste $a $d";
 echo $a + $d + 1 * 5 / 2;
 $c = $a + 5 + 2;
 $b = $a > 5;


### PR DESCRIPTION
Agora é possível a criação de constantes e usá-las da mesma forma que variáveis como em operações relacionais e lógicas, além da possibilidade de concatenar seu valor em strings.

Também é possível o uso de variáveis dentro de strings encapsuladas como em "Variavel $aqui".